### PR TITLE
DEV-9: Integrate with EBS

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -1,0 +1,26 @@
+files:
+    "/etc/nginx/nginx.conf":
+        mode: "000644"
+            owner: root
+            group: root
+            content: |
+                client_max_body_size 50M;
+
+files:
+    "/etc/nginx/conf.d/elasticbeanstalk/00_application.conf"
+        mode: "000644"
+        owner: root
+        group: root
+        content: |
+              client_max_body_size 50M;
+
+              location / {
+                  proxy_pass          http://127.0.0.1:8080;
+                  proxy_http_version  1.1;
+
+                  proxy_set_header    Connection          $connection_upgrade;
+                  proxy_set_header    Upgrade             $http_upgrade;
+                  proxy_set_header    Host                $host;
+                  proxy_set_header    X-Real-IP           $remote_addr;
+                  proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+              }

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>steganography</name>
 	<description>Steganography App</description>
 	<properties>
-		<java.version>24</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/java/com/rayyan/steganography/WebConfig.java
+++ b/src/main/java/com/rayyan/steganography/WebConfig.java
@@ -10,7 +10,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig {
 
     @Value("${cors.allowed-origins}")
-    private String[] allowedOrigins;
+    private String allowedOrigins;
 
     @Bean
     public WebMvcConfigurer corsConfigurer() {
@@ -18,7 +18,7 @@ public class WebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/api/**")
-                        .allowedOrigins(allowedOrigins)
+                        .allowedOrigins(allowedOrigins.split(","))
                         .allowedMethods("POST")
                         .allowedHeaders("*");
             }


### PR DESCRIPTION
Updated to be able to integrate with EBS and EC2.

Notes:
Rollback to Java 21 due to EC2 only supporting up to it
Permissive CORs hidden, used from EBS env variables instead